### PR TITLE
既存のAPIの修正

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,6 +1,5 @@
 class Api::V1::ArticlesController < Api::V1::BaseApiController
-  # before_action :current_user, only: [:create ]
-  # before_action :authenticate_api_v1_user!, only: [:create] #ログインユーザーでなければ実行されない
+  before_action :authenticate_api_v1_user!, only: [:create, :update, :destroy] # ログインユーザーでなければ実行されない
 
   def index
     Article.all
@@ -15,7 +14,7 @@ class Api::V1::ArticlesController < Api::V1::BaseApiController
 
   def create
     article = Article.new(article_params)
-    article.user_id = current_user.id # ログインユーザーのuser_idになる
+    article.user_id = current_api_v1_user.id # ログインユーザーのuser_idになる
     article.save!
     render json: article, serializer: Api::V1::ArticleSerializer
   end

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,7 +1,3 @@
 class Api::V1::BaseApiController < ApplicationController
   protect_from_forgery with: :null_session # CRF対策
-
-  def current_user
-    @current_user ||= User.first
-  end
 end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -36,18 +36,14 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "POST/api/v1/articles" do
-    subject { post(api_v1_articles_path, params: params) }
-
-    before do
-      create(:user)
-      @current_user ||= User.first
-    end
+    subject { post(api_v1_articles_path, params: params, headers: headers) }
 
     context "適切なパラメータを送信したとき" do
-      let(:params) { { article: attributes_for(:article, user_id: @current_user.id) } }
-      let(:user_id) { @current_user.article.id }
+      let(:params) { { article: attributes_for(:article, user_id: current_ap1_v1_user.id) } }
+
+      let(:current_ap1_v1_user) { create(:user) }
+      let(:headers) { current_ap1_v1_user.create_new_auth_token }
       it "記事のレコードを作成できる" do
-        allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(@current_user) # rubocop:disable all
         expect { subject }.to change { Article.count }.by(1)
         res = JSON.parse(response.body)
         expect(res["title"]).to eq params[:article][:title]
@@ -63,14 +59,15 @@ RSpec.describe "Api::V1::Articles", type: :request do
   # end
 
   describe " Patch(PUT) /api/v1/articles/:id" do
-    subject { patch(api_v1_article_path(article_id), params: params) }
+    subject { patch(api_v1_article_path(article_id), params: params, headers: headers) }
 
     let(:params) do
       { article: { title: Faker::Address.city, created_at: 1.day.ago } }
     end
     let(:article_id) { article.id }
-    let!(:article) { create(:article, user_id: user.id) }
-    let!(:user) { create(:user) }
+    let!(:article) { create(:article, user: current_ap1_v1_user) }
+    let!(:current_ap1_v1_user) { create(:user) }
+    let!(:headers) { current_ap1_v1_user.create_new_auth_token }
     it "任意のarticleのレコードを更新できる" do
       expect { subject }.to change { Article.find(article_id).title }.from(article.title).to(params[:article][:title]) &
                             not_change { Article.find(article_id).body } &
@@ -79,11 +76,12 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe " DELETE /api/v1/articles/:id" do
-    subject { delete(api_v1_article_path(article_id)) }
+    subject { delete(api_v1_article_path(article_id), headers: headers) }
 
     let(:article_id) { article.id }
-    let!(:article) { create(:article, user_id: user.id) }
-    let!(:user) { create(:user) }
+    let!(:article) { create(:article, user: current_ap1_v1_user) }
+    let!(:current_ap1_v1_user) { create(:user) }
+    let!(:headers) { current_ap1_v1_user.create_new_auth_token }
     it "任意のarticleのレコードが削除できる" do
       expect { subject }.to change { Article.count }.by(-1)
     end

--- a/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_spec.rb
@@ -37,12 +37,12 @@ RSpec.describe "Api::V1::Auth::Sessions", type: :request do
   describe "DELETE /api/v1/auth/sign_out" do
     subject { delete(destroy_api_v1_user_session_path, headers: headers) }
 
-    let(:user) { create(:user) }
-    let(:headers) { user.create_new_auth_token }
+    let!(:current_api_v1_user) { create(:user) }
+    let(:headers) { current_api_v1_user.create_new_auth_token }
 
     it "ログアウトできる" do
       subject
-      expect(user.reload.tokens).to be_blank
+      expect(current_api_v1_user.reload.tokens).to be_blank
       expect(response).to have_http_status(:ok)
     end
   end


### PR DESCRIPTION
## 概要
* ダミーで使用していたcurrent_userを削除し、current＿userを使用し、before＿action :autenticate _user!を使い、create,update,destroyにログイン状態でないと実行できないように制限をかけた。



## レビューポイント
* バージョニングしているため、 api_v1_user_signed_in?, current_api_v1_user,before_action :authenticate_api_v1_user!で対応できる。
