### PR TITLE
Article model に下書き機能を追加【下書き機能の実装】

### DIFF
--- a/app/controllers/api/v1/articles/drafts_controller.rb
+++ b/app/controllers/api/v1/articles/drafts_controller.rb
@@ -1,0 +1,14 @@
+class Api::V1::Articles::DraftsController < ApplicationController
+  before_action :authenticate_api_v1_user!
+
+  def index
+    Article.all
+    article = current_api_v1_user.articles.draft.order("updated_at DESC")
+    render json: article, each_serializer: Api::V1::ArticlePreviewSerializer
+  end
+
+  def show
+    article = current_api_v1_user.articles.draft.find(params[:id])
+    render json: article, serializer: Api::V1::ArticleSerializer
+  end
+end

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,23 +1,20 @@
 class Api::V1::ArticlesController < Api::V1::BaseApiController
-   before_action :authenticate_api_v1_user!, only: [:create, :update, :destroy] # ログインユーザーでなければ実行されない
+  before_action :authenticate_api_v1_user!, only: [:create, :update, :destroy] # ログインユーザーでなければ実行されない
 
   def index
-    binding.pry
     Article.all
-    binding.pry
     article = Article.published.order("updated_at DESC")
-    binding.pry
     render json: article, each_serializer: Api::V1::ArticlePreviewSerializer
   end
 
   def show
-    article = Article.find(params[:id])
+    article = Article.published.find(params[:id])
     render json: article, serializer: Api::V1::ArticleSerializer
   end
 
   def create
     article = Article.new(article_params)
-    article.user_id = current_api_v1_user.id# ログインユーザーのuser_idになる
+    article.user_id = current_api_v1_user.id # ログインユーザーのuser_idになる
     article.save!
     render json: article, serializer: Api::V1::ArticleSerializer
   end

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -2,6 +2,7 @@ class Api::V1::ArticlesController < Api::V1::BaseApiController
   before_action :authenticate_api_v1_user!, only: [:create, :update, :destroy] # ログインユーザーでなければ実行されない
 
   def index
+    binding.pry
     Article.all
     article = Article.order("updated_at DESC")
     render json: article, each_serializer: Api::V1::ArticlePreviewSerializer
@@ -13,6 +14,7 @@ class Api::V1::ArticlesController < Api::V1::BaseApiController
   end
 
   def create
+    binding.pry
     article = Article.new(article_params)
     article.user_id = current_api_v1_user.id # ログインユーザーのuser_idになる
     article.save!

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,10 +1,12 @@
 class Api::V1::ArticlesController < Api::V1::BaseApiController
-  before_action :authenticate_api_v1_user!, only: [:create, :update, :destroy] # ログインユーザーでなければ実行されない
+   before_action :authenticate_api_v1_user!, only: [:create, :update, :destroy] # ログインユーザーでなければ実行されない
 
   def index
     binding.pry
     Article.all
-    article = Article.order("updated_at DESC")
+    binding.pry
+    article = Article.published.order("updated_at DESC")
+    binding.pry
     render json: article, each_serializer: Api::V1::ArticlePreviewSerializer
   end
 
@@ -14,9 +16,8 @@ class Api::V1::ArticlesController < Api::V1::BaseApiController
   end
 
   def create
-    binding.pry
     article = Article.new(article_params)
-    article.user_id = current_api_v1_user.id # ログインユーザーのuser_idになる
+    article.user_id = current_api_v1_user.id# ログインユーザーのuser_idになる
     article.save!
     render json: article, serializer: Api::V1::ArticleSerializer
   end
@@ -39,6 +40,6 @@ class Api::V1::ArticlesController < Api::V1::BaseApiController
     # end
 
     def article_params
-      params.require(:article).permit(:title, :body)
+      params.require(:article).permit(:title, :body, :status)
     end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -21,7 +21,7 @@
 class Article < ApplicationRecord
 
   enum status: {draft: 0, published:1}
-  validates :body, :title, presence: true
+  validates :body, :title, :status, presence: true
   validates :title, length: { maximum: 30 }
 
   belongs_to :user

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -19,8 +19,7 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class Article < ApplicationRecord
-
-  enum status: {draft: 0, published:1}
+  enum status: { draft: 0, published: 1 }
   validates :body, :title, :status, presence: true
   validates :title, length: { maximum: 30 }
 

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
+#  status     :integer          default(0), not null
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -18,6 +19,8 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class Article < ApplicationRecord
+
+  enum status: {draft: 0, published:1}
   validates :body, :title, presence: true
   validates :title, length: { maximum: 30 }
 

--- a/app/serializers/api/v1/article_preview_serializer.rb
+++ b/app/serializers/api/v1/article_preview_serializer.rb
@@ -1,4 +1,4 @@
 class Api::V1::ArticlePreviewSerializer < ActiveModel::Serializer
-  attributes :id, :title, :updated_at
+  attributes :id, :title, :status, :updated_at
   belongs_to :user # , serializer: Api::V1::UserSerializer
 end

--- a/app/serializers/api/v1/article_serializer.rb
+++ b/app/serializers/api/v1/article_serializer.rb
@@ -1,5 +1,5 @@
 class Api::V1::ArticleSerializer < ActiveModel::Serializer
   attributes :id, :title, :body, :updated_at
 
-  belongs_to :user # , serializer: Api::V1::UserSerializer
+  belongs_to :user, serializer: Api::V1::UserSerializer
 end

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -42,11 +42,12 @@ DeviseTokenAuth.setup do |config|
   # config.default_callbacks = true
 
   # Makes it possible to change the headers names
-  # config.headers_names = {:'access-token' => 'access-token',
-  #                        :'client' => 'client',
-  #                        :'expiry' => 'expiry',
-  #                        :'uid' => 'uid',
-  #                        :'token-type' => 'token-type' }
+config.headers_names = { 'access-token': "access-token",
+                           client: "client",
+                           expiry: "expiry",
+                           uid: "uid",
+                           'token-type': "token-type" }
+
 
   # By default, only Bearer Token authentication is implemented out of the box.
   # If, however, you wish to integrate with legacy Devise authentication, you can

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -42,12 +42,11 @@ DeviseTokenAuth.setup do |config|
   # config.default_callbacks = true
 
   # Makes it possible to change the headers names
-config.headers_names = { 'access-token': "access-token",
+  config.headers_names = { 'access-token': "access-token",
                            client: "client",
                            expiry: "expiry",
                            uid: "uid",
                            'token-type': "token-type" }
-
 
   # By default, only Bearer Token authentication is implemented out of the box.
   # If, however, you wish to integrate with legacy Devise authentication, you can

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,10 @@ Rails.application.routes.draw do
       mount_devise_token_auth_for "User", at: "auth", controllers: {
         registrations: "api/v1/auth/registrations",
       }
+
+      namespace :articles do
+        resources :drafts, only: [:index, :show]
+      end
       resources :articles
     end
   end

--- a/db/migrate/20220418134353_add_status_to_articles.rb
+++ b/db/migrate/20220418134353_add_status_to_articles.rb
@@ -1,0 +1,5 @@
+class AddStatusToArticles < ActiveRecord::Migration[6.0]
+  def change
+    add_column :articles, :status, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_12_143151) do
+ActiveRecord::Schema.define(version: 2022_04_18_134353) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 2022_03_12_143151) do
     t.bigint "user_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "status", default: 0, null: false
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
+#  status     :integer          default(0), not null
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -29,16 +29,16 @@ RSpec.describe Article, type: :model do
   end
 
   context "body,title,statusが存在している時" do
-    fit "articleが下書きとして保存できる" do
+    it "articleが下書きとして保存できる" do
       article = FactoryBot.build(:article, status:0)
       expect(article).to be_valid
       expect(article.status).to eq "draft"
     end
 
-    fit "articleが公開として保存できる" do
+    it "articleが公開として保存できる" do
       article = FactoryBot.build(:article, status:1)
 
-      binding.pry
+
       expect(article).to be_valid
       expect(article.status).to eq "published"
     end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -30,23 +30,18 @@ RSpec.describe Article, type: :model do
 
   context "body,title,statusが存在している時" do
     it "articleが下書きとして保存できる" do
-      article = FactoryBot.build(:article, status:0)
+      article = FactoryBot.build(:article, status: 0)
       expect(article).to be_valid
       expect(article.status).to eq "draft"
     end
 
     it "articleが公開として保存できる" do
-      article = FactoryBot.build(:article, status:1)
-
+      article = FactoryBot.build(:article, status: 1)
 
       expect(article).to be_valid
       expect(article.status).to eq "published"
     end
   end
-
-
-
-
 
   context "bodyが存在しない時" do
     it "articleの作成に失敗する" do

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
+#  status     :integer          default(0), not null
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -26,6 +27,26 @@ RSpec.describe Article, type: :model do
       expect(article).to be_valid
     end
   end
+
+  context "body,title,statusが存在している時" do
+    fit "articleが下書きとして保存できる" do
+      article = FactoryBot.build(:article, status:0)
+      expect(article).to be_valid
+      expect(article.status).to eq "draft"
+    end
+
+    fit "articleが公開として保存できる" do
+      article = FactoryBot.build(:article, status:1)
+
+      binding.pry
+      expect(article).to be_valid
+      expect(article.status).to eq "published"
+    end
+  end
+
+
+
+
 
   context "bodyが存在しない時" do
     it "articleの作成に失敗する" do

--- a/spec/requests/api/v1/articles/drafts_spec.rb
+++ b/spec/requests/api/v1/articles/drafts_spec.rb
@@ -1,0 +1,74 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Articles::Drafts", type: :request do
+  describe "GET /api/v1/articles/drafts" do
+    # index正常系
+    context "ログイン状態で記事のstatusがdraftの場合" do
+      subject { get(api_v1_articles_drafts_path, headers: headers) }
+
+      let!(:article) { create_list(:article, article_count, user: current_ap1_v1_user, status: 0) }
+      let(:article_count) { 3 }
+      let(:article_id) { article.id }
+      let!(:current_ap1_v1_user) { create(:user) }
+      let!(:headers) { current_ap1_v1_user.create_new_auth_token }
+      it "ログインしているユーザーの下書き一覧を表示できる" do
+        subject
+        res = JSON.parse(response.body)
+        expect(res.length).to eq article_count
+        expect(res.sort_by {|hash| -hash["created_at"].to_i }).to eq res.sort_by { "created_at" }
+        expect(res[0].keys).to eq ["id", "title", "status","updated_at", "user"]
+        expect(res[0]["user"].keys).to eq ["id", "provider", "uid", "allow_password_change", "name", "nickname", "image", "email", "created_at", "updated_at"]
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    # index異常系
+    context "ログイン状態で記事のstatusがpublishedの場合" do
+      subject { get(api_v1_articles_drafts_path, headers: headers) }
+
+      let!(:article) { create_list(:article, article_count, user: current_ap1_v1_user, status: 1) }
+      let(:article_count) { 3 }
+      let(:article_id) { article.id }
+      let!(:current_ap1_v1_user) { create(:user) }
+      let!(:headers) { current_ap1_v1_user.create_new_auth_token }
+      it "ログインしているユーザーの下書き一覧を表示されない" do
+        subject
+        res = JSON.parse(response.body)
+        expect(res).to eq []
+      end
+    end
+  end
+
+  describe "GET /api/v1/articles/:id" do
+    subject { get(api_v1_articles_draft_path(article_id), headers: headers) }
+
+    # show正常系
+    context "ログインユーザの記事がdraftの場合" do
+      let!(:article) { create(:article, user: current_ap1_v1_user, status: 0) }
+      let(:article_id) { article.id }
+      let!(:current_ap1_v1_user) { create(:user) }
+      let(:headers) { current_ap1_v1_user.create_new_auth_token }
+      it "指定された記事が表示される" do
+        subject
+        res = JSON.parse(response.body)
+        expect(article.status).to eq "draft"
+        expect(res["title"]).to eq article.title
+        expect(res["body"]).to eq article.body
+        expect(res["updated_at"]).to be_present
+        expect(res["user"]["id"]).to eq article.user.id
+        expect(res["user"].keys).to eq ["id", "name", "email"]
+      end
+    end
+
+    # show異常系
+    context "ログインユーザの記事がpublishedの場合" do
+      let!(:article) { create(:article, user: current_ap1_v1_user, status: 1) }
+      let(:article_id) { article.id }
+      let!(:current_ap1_v1_user) { create(:user) }
+      let(:headers) { current_ap1_v1_user.create_new_auth_token }
+      it "指定された記事が表示されない" do
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/articles/drafts_spec.rb
+++ b/spec/requests/api/v1/articles/drafts_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Api::V1::Articles::Drafts", type: :request do
         res = JSON.parse(response.body)
         expect(res.length).to eq article_count
         expect(res.sort_by {|hash| -hash["created_at"].to_i }).to eq res.sort_by { "created_at" }
-        expect(res[0].keys).to eq ["id", "title", "status","updated_at", "user"]
+        expect(res[0].keys).to eq ["id", "title", "status", "updated_at", "user"]
         expect(res[0]["user"].keys).to eq ["id", "provider", "uid", "allow_password_change", "name", "nickname", "image", "email", "created_at", "updated_at"]
         expect(response).to have_http_status(:ok)
       end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -5,12 +5,14 @@ RSpec.describe "Api::V1::Articles", type: :request do
     subject { get(api_v1_articles_path) }
 
     before { create_list(:article, article_count) }
-
+    before{ Article.update_all(status: "published") }
     let(:article_count) { 3 }
-    it "記事の一覧が表示される" do
+    fit "記事の一覧が表示される" do
       subject
-      Article.all
+      binding.pry
+      # Article.update_all(status: "published")
       res = JSON.parse(response.body)
+      binding.pry
       expect(res.length).to eq article_count
       expect(res.sort_by {|hash| -hash["created_at"].to_i }).to eq res.sort_by { "created_at" }
       expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]


### PR DESCRIPTION
## Article modelに下書き機能を追加
* enum機能を使い、公開記事と下書きを設定できるように実装した。
*  既存のAPI を修正し、公開記事のみを表示し、テストも合わせて実装した。
* drafts_controllerを作成し、ログインユーザーの下書き記事を表示できるようにAPI を実装し、テストも合わせて実装した。



## レビューポイント
* drafts_specのcurrent_userを設定する時、headersにてトークンを送らないとcurrent_userを使用できない。devise_token_authの特徴がよく理解できた。
* 下書きのcontrollerを作成した。articles_controllerと分岐させ、コントローラを分けることで、index,show,create,update,destory以外のアクションを追加しないように実装した。