### PR TITLE
自分が書いた記事の一覧を取得するapiとテストの実装

### DIFF
--- a/app/controllers/api/v1/current/articles_controller.rb
+++ b/app/controllers/api/v1/current/articles_controller.rb
@@ -1,0 +1,2 @@
+class Api::V1::Current::ArticlesController < ApplicationController
+end

--- a/app/controllers/api/v1/current/articles_controller.rb
+++ b/app/controllers/api/v1/current/articles_controller.rb
@@ -4,7 +4,6 @@ class Api::V1::Current::ArticlesController < ApplicationController
   def index
     Article.all
     article = current_api_v1_user.articles.published.order("updated_at DESC")
-    binding.pry
     render json: article, each_serializer: Api::V1::ArticlePreviewSerializer
   end
 
@@ -12,13 +11,4 @@ class Api::V1::Current::ArticlesController < ApplicationController
     article = current_api_v1_user.articles.published.find(params[:id])
     render json: article, serializer: Api::V1::ArticleSerializer
   end
-
-
-
-
-
-
-
-
-
 end

--- a/app/controllers/api/v1/current/articles_controller.rb
+++ b/app/controllers/api/v1/current/articles_controller.rb
@@ -1,2 +1,24 @@
 class Api::V1::Current::ArticlesController < ApplicationController
+  before_action :authenticate_api_v1_user!
+
+  def index
+    Article.all
+    article = current_api_v1_user.articles.published.order("updated_at DESC")
+    binding.pry
+    render json: article, each_serializer: Api::V1::ArticlePreviewSerializer
+  end
+
+  def show
+    article = current_api_v1_user.articles.published.find(params[:id])
+    render json: article, serializer: Api::V1::ArticleSerializer
+  end
+
+
+
+
+
+
+
+
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,11 @@ Rails.application.routes.draw do
       namespace :articles do
         resources :drafts, only: [:index, :show]
       end
+
+      namespace :current do
+        resources :articles
+      end
+
       resources :articles
     end
   end

--- a/spec/requests/api/v1/current/articles_spec.rb
+++ b/spec/requests/api/v1/current/articles_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Current::Articles", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/api/v1/current/articles_spec.rb
+++ b/spec/requests/api/v1/current/articles_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.describe "Api::V1::Current::Articles", type: :request do
   describe "GET /api/v1/current/article" do
-
     # index正常系
     subject { get(api_v1_current_articles_path, headers: headers) }
 
@@ -12,7 +11,6 @@ RSpec.describe "Api::V1::Current::Articles", type: :request do
       let(:article_id) { article.id }
       let(:current_ap1_v1_user) { create(:user) }
       let(:headers) { current_ap1_v1_user.create_new_auth_token }
-      let!(:article_a) { create(:article, status: 1) }
       it "ログインしているユーザーの公開記事一覧を表示できる" do
         subject
         res = JSON.parse(response.body)
@@ -32,7 +30,7 @@ RSpec.describe "Api::V1::Current::Articles", type: :request do
       let(:article_id) { article.id }
       let!(:current_ap1_v1_user) { create(:user) }
       let(:headers) { current_ap1_v1_user.create_new_auth_token }
-      fit "ログインしているユーザーの公開一覧を表示されない" do
+      it "ログインしているユーザーの公開一覧を表示されない" do
         subject
         res = JSON.parse(response.body)
         expect(res).to eq []

--- a/spec/requests/api/v1/current/articles_spec.rb
+++ b/spec/requests/api/v1/current/articles_spec.rb
@@ -1,7 +1,74 @@
 require 'rails_helper'
 
 RSpec.describe "Api::V1::Current::Articles", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+  describe "GET /api/v1/current/article" do
+    # index正常系
+
+      subject { get(api_v1_current_articles_path, headers: headers) }
+      context "ログイン状態で記事のstatusがpublishedの場合" do
+      let!(:article) { create_list(:article, article_count, user: current_ap1_v1_user, status: 1) }
+      let(:article_count) { 3 }
+      let(:article_id) { article.id }
+      let!(:current_ap1_v1_user) { create(:user) }
+      let!(:headers) { current_ap1_v1_user.create_new_auth_token }
+      let!(:article_a) { create(:article, status: 1) }
+      it "ログインしているユーザーの公開記事一覧を表示できる" do
+        subject
+        res = JSON.parse(response.body)
+        expect(res.length).to eq article_count
+        expect(res.sort_by {|hash| -hash["created_at"].to_i }).to eq res.sort_by { "created_at" }
+        expect(res[0]["status"]).to eq "published"
+        expect(res[0].keys).to eq ["id", "title", "status", "updated_at", "user"]
+        expect(res[0]["user"].keys).to eq ["id", "provider", "uid", "allow_password_change", "name", "nickname", "image", "email", "created_at", "updated_at"]
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    # index異常系
+    context "ログイン状態で記事のstatusが下書き記事のみ場合" do
+      let!(:article) { create_list(:article, article_count, user: current_ap1_v1_user, status: 0) }
+      let(:article_count) { 3 }
+      let(:article_id) { article.id }
+      let!(:current_ap1_v1_user) { create(:user) }
+      let!(:headers) { current_ap1_v1_user.create_new_auth_token }
+      it "ログインしているユーザーの公開一覧を表示されない" do
+        subject
+        res = JSON.parse(response.body)
+        expect(res).to eq []
+      end
+    end
+  end
+
+  describe "GET /api/v1/current/articles/:id" do
+    subject { get(api_v1_current_article_path(article_id), headers: headers) }
+
+    # show正常系
+    context "ログインユーザの記事が公開記事の場合" do
+      let!(:article) { create(:article, user: current_ap1_v1_user, status: 1) }
+      let(:article_id) { article.id }
+      let!(:current_ap1_v1_user) { create(:user) }
+      let(:headers) { current_ap1_v1_user.create_new_auth_token }
+      it "指定された記事が表示される" do
+        subject
+        res = JSON.parse(response.body)
+        expect(article.status).to eq "published"
+        expect(res["title"]).to eq article.title
+        expect(res["body"]).to eq article.body
+        expect(res["updated_at"]).to be_present
+        expect(res["user"]["id"]).to eq article.user.id
+        expect(res["user"].keys).to eq ["id", "name", "email"]
+      end
+    end
+
+    # show異常系
+    context "指定された記事がログインユーザー以外の場合" do
+      let!(:article) { create(:article,  status: 1) }
+      let(:article_id) { article.id }
+      let!(:current_ap1_v1_user) { create(:user) }
+      let(:headers) { current_ap1_v1_user.create_new_auth_token }
+      fit "指定された記事が表示されない" do
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/current/articles_spec.rb
+++ b/spec/requests/api/v1/current/articles_spec.rb
@@ -1,16 +1,17 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "Api::V1::Current::Articles", type: :request do
   describe "GET /api/v1/current/article" do
-    # index正常系
 
-      subject { get(api_v1_current_articles_path, headers: headers) }
-      context "ログイン状態で記事のstatusがpublishedの場合" do
+    # index正常系
+    subject { get(api_v1_current_articles_path, headers: headers) }
+
+    context "ログイン状態で記事のstatusがpublishedの場合" do
       let!(:article) { create_list(:article, article_count, user: current_ap1_v1_user, status: 1) }
       let(:article_count) { 3 }
       let(:article_id) { article.id }
-      let!(:current_ap1_v1_user) { create(:user) }
-      let!(:headers) { current_ap1_v1_user.create_new_auth_token }
+      let(:current_ap1_v1_user) { create(:user) }
+      let(:headers) { current_ap1_v1_user.create_new_auth_token }
       let!(:article_a) { create(:article, status: 1) }
       it "ログインしているユーザーの公開記事一覧を表示できる" do
         subject
@@ -30,8 +31,8 @@ RSpec.describe "Api::V1::Current::Articles", type: :request do
       let(:article_count) { 3 }
       let(:article_id) { article.id }
       let!(:current_ap1_v1_user) { create(:user) }
-      let!(:headers) { current_ap1_v1_user.create_new_auth_token }
-      it "ログインしているユーザーの公開一覧を表示されない" do
+      let(:headers) { current_ap1_v1_user.create_new_auth_token }
+      fit "ログインしているユーザーの公開一覧を表示されない" do
         subject
         res = JSON.parse(response.body)
         expect(res).to eq []
@@ -62,11 +63,11 @@ RSpec.describe "Api::V1::Current::Articles", type: :request do
 
     # show異常系
     context "指定された記事がログインユーザー以外の場合" do
-      let!(:article) { create(:article,  status: 1) }
+      let!(:article) { create(:article, status: 1) }
       let(:article_id) { article.id }
       let!(:current_ap1_v1_user) { create(:user) }
       let(:headers) { current_ap1_v1_user.create_new_auth_token }
-      fit "指定された記事が表示されない" do
+      it "指定された記事が表示されない" do
         expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end


### PR DESCRIPTION
## 概要
* ログインユーザーの記事一覧、詳細を表示できるように実装
* テストでは公開記事が表示されるか、下書き記事は非表示になるかをテストした。


## レビューポイント
* drafts_controllerと似たような実装になった。


