### PR TITLE
faker gemを本番環境でも使えるようにする

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ group :development, :test do
   gem "factory_bot_rails"
   # gem "faker"
   gem "rspec-rails"
-
+  gem "faker"
   gem "rails-erd"
   gem "rails-i18n"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -66,3 +66,4 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem "faker"

--- a/Gemfile
+++ b/Gemfile
@@ -47,10 +47,10 @@ group :development, :test do
 
   gem "factory_bot_rails"
   # gem "faker"
-  gem "rspec-rails"
   gem "faker"
   gem "rails-erd"
   gem "rails-i18n"
+  gem "rspec-rails"
 end
 
 group :development do
@@ -58,10 +58,10 @@ group :development do
   gem "listen", "~> 3.2"
   gem "web-console", ">= 3.3.0"
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
+  gem "annotate"
+
   gem "spring"
   gem "spring-watcher-listen", "~> 2.0.0"
-  gem "faker"
-  gem "annotate"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem "bootsnap", ">= 1.4.2", require: false
 gem "devise_token_auth"
 # CORS設定
 gem "rack-cors"
-
+# gem "faker"
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]
@@ -46,7 +46,7 @@ group :development, :test do
   gem "rubocop-rspec"
 
   gem "factory_bot_rails"
-  gem "faker"
+  # gem "faker"
   gem "rspec-rails"
 
   gem "rails-erd"
@@ -66,4 +66,3 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
-gem "faker"

--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem "spring"
   gem "spring-watcher-listen", "~> 2.0.0"
-
+  gem "faker"
   gem "annotate"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,7 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
-    faker (2.20.0)
+    faker (2.21.0)
       i18n (>= 1.8.11, < 2)
     ffi (1.15.5)
     globalid (1.0.0)


### PR DESCRIPTION
## 概要
* herokuのデプロイにおいてエラーが発生した為、gemの追加をした
* エラー内容
*    NameError: uninitialized constant WonderfulEditor::Application::Faker